### PR TITLE
Fix TypeError: 'str' does not support the buffer interface

### DIFF
--- a/savacli
+++ b/savacli
@@ -235,7 +235,7 @@ class Protocol(object):
                     # Alert found
                     elif number == 310:
                         self.__scanner.count_infected()
-                        alert_name, status, description = message.split(";")
+                        alert_name, status, description = message.decode().split(";")
                         self.__alerts.append(
                             dict(path=path,
                                  alert_name=alert_name.strip(),
@@ -273,7 +273,7 @@ class Protocol(object):
                     elif number == 420:
                         self.__scanner.count_infected()
                         self.__scanner.count_repairable()
-                        alert_name, status, description = message.split(";")
+                        alert_name, status, description = message.decode().split(";")
                         self.__alerts.append(
                             dict(path=path,
                                  alert_name=alert_name.strip(),


### PR DESCRIPTION
```python
C:\python34\python.exe savacli.py -c savacli.conf -r -i C:\Downloads\
Traceback (most recent call last):
  File "savacli.py", line 900, in <module>
    exit_code = main()
  File "savacli.py", line 819, in main
    scanner.scan(entry)
  File "savacli.py", line 395, in scan
    self.__proto.scan(path)
  File "savacli.py", line 62, in wrapper
    result = f(*p, **kw)
  File "savacli.py", line 238, in scan
    alert_name, status, description = message.split(";")
TypeError: 'str' does not support the buffer interface
```